### PR TITLE
전체화면에서 페이지 번호 표시 기능 추가

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2566,3 +2566,177 @@ body:has(#presentation-section:not(.hidden)) .footer-container {
 .dark .slide-thumbnail-content a {
     color: #60a5fa;
 }
+
+#fullscreen-page-number {
+    position: fixed !important;
+    backdrop-filter: blur(6px) !important;
+    -webkit-backdrop-filter: blur(6px) !important;
+    color: #99999a !important;
+    padding: 8px 12px !important;
+    border-radius: 12px !important;
+    font-size: 18px !important;
+    font-weight: 600 !important;
+    z-index: 10001 !important;
+    opacity: 0 !important;
+    transform: translateY(20px) !important;
+    transition: all 0.3s ease !important;
+    pointer-events: none !important;
+    user-select: none !important;
+    display: none !important;
+}
+
+#fullscreen-page-number.show {
+    display: block !important;
+    opacity: 1 !important;
+    transform: translateY(0) !important;
+}
+
+#fullscreen-page-number.bottom-right {
+    bottom: 24px !important;
+    right: 24px !important;
+    top: auto !important;
+    left: auto !important;
+}
+
+#fullscreen-page-number.top-right {
+    top: 24px !important;
+    right: 24px !important;
+    bottom: auto !important;
+    left: auto !important;
+}
+
+#fullscreen-page-number.top-left {
+    top: 24px !important;
+    left: 24px !important;
+    bottom: auto !important;
+    right: auto !important;
+}
+
+#fullscreen-page-number.bottom-left {
+    bottom: 24px !important;
+    left: 24px !important;
+    top: auto !important;
+    right: auto !important;
+}
+
+#slide-container:fullscreen #fullscreen-page-number,
+#slide-container:-webkit-full-screen #fullscreen-page-number,
+#slide-container:-moz-full-screen #fullscreen-page-number,
+#slide-container:-ms-fullscreen #fullscreen-page-number,
+#slide-container.fullscreen #fullscreen-page-number {
+    display: block !important;
+    opacity: 1 !important;
+    transform: translateY(0) !important;
+    visibility: visible !important;
+}
+
+#slide-container.fullscreen-fallback #fullscreen-page-number {
+    display: block !important;
+    opacity: 1 !important;
+    transform: translateY(0) !important;
+    visibility: visible !important;
+}
+
+@media (max-width: 768px) {
+    #fullscreen-page-number {
+        font-size: 16px;
+        padding: 10px 16px;
+    }
+
+    #fullscreen-page-number.bottom-right {
+        bottom: 100px;
+        right: 16px;
+        top: auto !important;
+        left: auto !important;
+    }
+
+    #fullscreen-page-number.top-right {
+        top: 16px;
+        right: 16px;
+        bottom: auto !important;
+        left: auto !important;
+    }
+
+    #fullscreen-page-number.top-left {
+        top: 16px;
+        left: 16px;
+        bottom: auto !important;
+        right: auto !important;
+    }
+
+    #fullscreen-page-number.bottom-left {
+        bottom: 100px;
+        left: 16px;
+        top: auto !important;
+        right: auto !important;
+    }
+
+    /* Mobile fullscreen adjustments */
+    #presentation-section #slide-container #fullscreen-page-number {
+        bottom: 100px;
+        right: 16px;
+    }
+
+    #presentation-section #slide-container #fullscreen-page-number.bottom-right {
+        bottom: 100px;
+        right: 16px;
+        top: auto !important;
+        left: auto !important;
+    }
+
+    #presentation-section #slide-container #fullscreen-page-number.top-right {
+        top: 16px;
+        right: 16px;
+        bottom: auto !important;
+        left: auto !important;
+    }
+
+    #presentation-section #slide-container #fullscreen-page-number.top-left {
+        top: 16px;
+        left: 16px;
+        bottom: auto !important;
+        right: auto !important;
+    }
+
+    #presentation-section #slide-container #fullscreen-page-number.bottom-left {
+        bottom: 100px;
+        left: 16px;
+        top: auto !important;
+        right: auto !important;
+    }
+}
+
+@media (max-width: 480px) {
+    #fullscreen-page-number {
+        font-size: 14px;
+        padding: 8px 12px;
+    }
+
+    #fullscreen-page-number.bottom-right {
+        bottom: 90px;
+        right: 12px;
+        top: auto !important;
+        left: auto !important;
+    }
+
+    #fullscreen-page-number.top-right {
+        top: 12px;
+        right: 12px;
+        bottom: auto !important;
+        left: auto !important;
+    }
+
+    #fullscreen-page-number.top-left {
+        top: 12px;
+        left: 12px;
+        bottom: auto !important;
+        right: auto !important;
+    }
+
+    #fullscreen-page-number.bottom-left {
+        bottom: 90px;
+        left: 12px;
+        top: auto !important;
+        right: auto !important;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -231,14 +231,47 @@
                                     </select>
                                 </div>
 
+                                <hr>
+                                
+                                <!-- 전체화면 페이지 번호 설정 -->
+                                <div>
+                                    <label class="flex items-center cursor-pointer">
+                                        <input type="checkbox" id="fullscreen-page-number-toggle" class="mr-2 text-blue-600 rounded focus:ring-blue-500">
+                                        <span class="text-xs font-medium text-gray-700 dark:text-white">전체화면 페이지 번호 표시</span>
+                                    </label>
+                                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">전체화면 모드에서 현재 페이지 번호를 표시합니다.</p>
+
+                                    <div class="mt-2 fullscreen-page-number-options" style="display: none;">
+                                        <label for="fullscreen-page-number-position" class="block text-xs font-medium text-gray-700 dark:text-white mb-1">
+                                            페이지 번호 위치
+                                        </label>
+                                        <select id="fullscreen-page-number-position" class="w-full px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                                            <option value="bottom-right">우하단</option>
+                                            <option value="top-right">우상단</option>
+                                            <option value="top-left">좌상단</option>
+                                            <option value="bottom-left">좌하단</option>
+                                        </select>
+                                    </div>
+
+                                    <div class="mt-2 fullscreen-page-number-options" style="display: none;">
+                                        <label for="fullscreen-page-number-format" class="block text-xs font-medium text-gray-700 dark:text-white mb-1">
+                                            페이지 번호 형식
+                                        </label>
+                                        <select id="fullscreen-page-number-format" class="w-full px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                                            <option value="current-total">현재/전체 (1/10)</option>
+                                            <option value="current-only">현재 페이지 (1)</option>
+                                        </select>
+                                    </div>
+                                </div>
+
+                                <hr />
+
                                 <!-- 설정 초기화 버튼 -->
                                 <div class="pt-2">
                                     <button id="reset-fonts-btn" class="w-full px-3 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors border border-red-200 dark:border-red-800">
-                                        폰트 설정 초기화
+                                        설정 초기화
                                     </button>
                                 </div>
-
-                                <hr>
                                 
                                 <!-- Help Button -->
                                 <div class="pt-4">
@@ -625,13 +658,20 @@
 
 
             <!-- Slide Container -->
-            <div id="slide-container" class="min-h-[calc(100vh-64px)] overflow-y-auto overflow-x-hidden flex items-start md:items-center justify-center px-4 md:px-4 py-8 md:py-8 scroll-smooth -webkit-overflow-scrolling-touch scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-400/50 hover:scrollbar-thumb-gray-400/80 dark:scrollbar-thumb-gray-500/50 dark:hover:scrollbar-thumb-gray-500/80 bg-white dark:bg-gray-900" style="scrollbar-width: thin; scrollbar-color: rgba(156, 163, 175, 0.5) transparent;">
+            <div id="slide-container" class="min-h-[calc(100vh-64px)] overflow-y-auto overflow-x-hidden flex items-start md:items-center justify-center px-4 md:px-4 py-8 md:py-8 scroll-smooth -webkit-overflow-scrolling-touch scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-400/50 hover:scrollbar-thumb-gray-400/80 dark:scrollbar-thumb-gray-500/50 dark:hover:scrollbar-thumb-gray-500/80 bg-white dark:bg-gray-900 relative" style="scrollbar-width: thin; scrollbar-color: rgba(156, 163, 175, 0.5) transparent;">
                 <div id="slide-content" class="max-w-[90vw] w-full bg-white dark:bg-gray-800 dark:text-gray-100 rounded-lg shadow-lg p-32 prose prose-lg dark:prose-invert max-w-none relative transition-all duration-300 break-words flex flex-col gap-6" style="font-size: 3rem; line-height: 1.8;"
                     <!-- Presentation Logo -->
                     <div id="presentation-logo" class="absolute top-10 left-10 cursor-pointer hidden z-20">
                         <img id="logo-image" class="max-w-8 max-h-8 object-contain" alt="Presentation Logo">
                     </div>
                     <!-- Slide content will be rendered here -->
+                </div>
+
+                <!-- Fullscreen Page Number -->
+                <div id="fullscreen-page-number" class="fixed bottom-6 right-6 px-4 py-2 font-semibold text-lg z-[10001]">
+                    <span id="current-page-number">1</span>
+                    <span class="mx-1">/</span>
+                    <span id="total-page-number">1</span>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
주요 추가 사항
- 페이지 번호 표시 기능 켜기 / 끄기
- 페이지 번호 위치 설정(우상단, 우하단, 좌상단, 좌하단)
- 페이지 번호 형식 설정(00/00, 00)

주요 구현 사항
- 페이지 번호 업데이트 및 표시/숨김 처리를 위한 `updateFullscreenPageNumber()` 추가
- 옵션 표시/숨김 및 비활성화 처리를 위한 `updateFullscreenPageNumberOptionsVisibility()` 추가
- settings structure에 Fullscreen관련한 옵션 추가
    ```javascript
    settings = {
        ...생략...
        showFullscreenPageNumber: true,
        fullscreenPageNumberPosition: 'bottom-right',
        fullscreenPageNumberFormat: 'current-total'
    }
    ```

<img width="200" alt="updated settings img" src="https://github.com/user-attachments/assets/53c94ad9-bc37-459a-918d-dfa3b9e2c9f5" />
<img width="500" alt="fullscreen page number img" src="https://github.com/user-attachments/assets/9d2f46e0-798b-4d11-a980-34b83b94780e" />

